### PR TITLE
Use sling.Doer instead of http.Client in twitter.Client.

### DIFF
--- a/twitter/streams.go
+++ b/twitter/streams.go
@@ -20,14 +20,14 @@ const (
 
 // StreamService provides methods for accessing the Twitter Streaming API.
 type StreamService struct {
-	client *http.Client
+	client sling.Doer
 	public *sling.Sling
 	user   *sling.Sling
 	site   *sling.Sling
 }
 
 // newStreamService returns a new StreamService.
-func newStreamService(client *http.Client, sling *sling.Sling) *StreamService {
+func newStreamService(client sling.Doer, sling *sling.Sling) *StreamService {
 	sling.Set("User-Agent", userAgent)
 	return &StreamService{
 		client: client,
@@ -142,7 +142,7 @@ func (srv *StreamService) Firehose(params *StreamFirehoseParams) (*Stream, error
 // The client must Stop() the stream when finished receiving, which will
 // wait until the stream is properly stopped.
 type Stream struct {
-	client   *http.Client
+	client   sling.Doer
 	Messages chan interface{}
 	done     chan struct{}
 	group    *sync.WaitGroup
@@ -152,7 +152,7 @@ type Stream struct {
 // newStream creates a Stream and starts a goroutine to retry connecting and
 // receive from a stream response. The goroutine may stop due to retry errors
 // or be stopped by calling Stop() on the stream.
-func newStream(client *http.Client, req *http.Request) *Stream {
+func newStream(client sling.Doer, req *http.Request) *Stream {
 	s := &Stream{
 		client:   client,
 		Messages: make(chan interface{}),

--- a/twitter/twitter.go
+++ b/twitter/twitter.go
@@ -30,8 +30,13 @@ type Client struct {
 }
 
 // NewClient returns a new Client.
-func NewClient(httpClient *http.Client) *Client {
-	base := sling.New().Client(httpClient).Base(twitterAPI)
+//
+// *http.Client implements the sling.Doer interface.
+func NewClient(httpClient sling.Doer) *Client {
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	base := sling.New().Doer(httpClient).Base(twitterAPI)
 	return &Client{
 		sling:          base,
 		Accounts:       newAccountService(base.New()),


### PR DESCRIPTION
Allows wrapping http.Client with layers of Doers to form a stack of
client-side middleware.